### PR TITLE
Add new move and focus modes.

### DIFF
--- a/autoload/winresizer.vim
+++ b/autoload/winresizer.vim
@@ -32,4 +32,34 @@ fun! winresizer#canMoveCursorFromCurrentWindow(direct)
   return from != to
 endfun
 
+fun! winresizer#swapTo(direct)
+  let direct = 'left'
+  let map_direct = {'left':'h', 'down':'j', 'up':'k', 'right':'l'}
+  if has_key(map_direct, a:direct)
+    let direct = map_direct[a:direct]
+  elseif index(values(map_direct), a:direct) != -1
+    let direct = a:direct
+  endif
+  let from = winnr()
+  exe "wincmd " . direct
+  let to = winnr()
+  exe from . "wincmd w"
+
+  if to != from
+    call winresizer#swapWindow(to)
+  endif
+
+endfun
+
+fun! winresizer#swapWindow(to)
+  let curNum = winnr()
+  let curBuf = bufnr( "%" )
+  exe a:to . "wincmd w"
+  let toBuf  = bufnr( "%" )
+  exe 'hide buf' curBuf
+  exe curNum . "wincmd w"
+  exe 'hide buf' toBuf
+  exe a:to ."wincmd w"
+endfun
+
 let &cpo = s:save_cpo

--- a/plugin/winresizer.vim
+++ b/plugin/winresizer.vim
@@ -1,7 +1,7 @@
 "---------------------------------------------------
 " WinResizer 
 "---------------------------------------------------
-" This is simple plugin to resize window size 
+" This is simple plugin to resize/move windows
 " for someone using vim with split windows  
 "
 " ========================================
@@ -18,7 +18,26 @@
 " j : expand window size to down
 " k : expand window size to up
 " l : expand window size to right
-" q : cancel resize window and escepe [window resize mode]
+" e : switch to move mode
+" q : cancel resize window and escape [window resize mode]
+" Enter : fix and escape 
+"
+" keymap of [window move mode]
+" h : move window left
+" j : move window down
+" k : move window up
+" l : move window right
+" e : switch to focus mode
+" q : cancel move window and escape [window move mode]
+" Enter : fix and escape 
+"
+" keymap of [window focus mode]
+" h : move focus to left window
+" j : move focus to window below
+" k : move focus to window above
+" l : move focus to right window
+" e : switch to resize mode
+" q : cancel move window and escape [window focus mode]
 " Enter : fix and escape 
 
 if exists("g:loaded_winresizer")
@@ -55,6 +74,7 @@ let s:default_keycode = {
              \           'finish':'13',
              \           'cancel':'113',
              \           'escape':'27',
+             \           'mode'  :'101',
              \          }
 
 let g:winresizer_keycode_left  = get(g:, 'winresizer_keycode_left', s:default_keycode['left'])
@@ -65,6 +85,7 @@ let g:winresizer_keycode_right = get(g:, 'winresizer_keycode_right', s:default_k
 let g:winresizer_keycode_finish = get(g:, 'winresizer_keycode_finish', s:default_keycode['finish'])
 let g:winresizer_keycode_cancel = get(g:, 'winresizer_keycode_cancel', s:default_keycode['cancel'])
 let g:winresizer_keycode_escape = get(g:, 'winresizer_keycode_escape', s:default_keycode['escape'])
+let g:winresizer_keycode_mode   = get(g:, 'winresizer_keycode_mode', s:default_keycode['mode'])
 
 " if <ESC> key downed, finish resize mode
 let g:winresizer_finish_with_escape = get(g:, 'winresizer_finish_with_escape', 1)
@@ -74,40 +95,41 @@ let s:codeList = {
         \  'down' : g:winresizer_keycode_down,
         \  'up'   : g:winresizer_keycode_up,
         \  'right': g:winresizer_keycode_right,
+        \  'mode' : g:winresizer_keycode_mode,
         \}
 
 exe 'nnoremap ' . g:winresizer_start_key .' :WinResizerStartResize<CR>'
 
-com! WinResizerStartResize call WinResizerStartResize()
+com! WinResizerStartResize call s:startReize(s:resizeCommands())
+com! WinResizerStartMove call s:startReize(s:moveCommands())
+com! WinResizerStartFocus call s:startReize(s:focusCommands())
 
 if has("gui_running") && g:winresizer_gui_enable != 0
   exe 'nnoremap ' . g:winresizer_gui_start_key .' :WinResizerStartResizeGUI<CR>'
-  com! WinResizerStartResizeGUI call WinResizerStartResizeGUI()
+  com! WinResizerStartResizeGUI call s:startReize(s:guiResizeCommands())
 endif
 
-fun! WinResizerStartResizeGUI()
-  if g:winresizer_enable == 0
-    return
-  endif
+fun! s:guiResizeCommands()
+
   let commands = {
+      \  'mode'   : "resize",
       \  'left'   : 'let &columns = &columns - ' . g:winresizer_vert_resize,
       \  'right'  : 'let &columns = &columns + ' . g:winresizer_vert_resize,
       \  'up'     : 'let &lines = &lines - ' . g:winresizer_horiz_resize,
       \  'down'   : 'let &lines = &lines + ' . g:winresizer_horiz_resize,
       \  'cancel' : 'let &columns = ' . &columns . '|let &lines = ' . &lines . '|',
       \}
-  call s:startReize(commands)
+
+  return commands
 
 endfun
 
-fun! WinResizerStartResize()
-  if g:winresizer_enable == 0
-    return
-  endif
+fun! s:tuiResizeCommands()
 
   let behavior = s:getResizeBehavior()
 
   let commands = {
+        \  'mode'   : "resize",
         \  'left'   : ':vertical resize ' . behavior['left']  . g:winresizer_vert_resize,
         \  'right'  : ':vertical resize ' . behavior['right'] . g:winresizer_vert_resize,
         \  'up'     : ':resize ' . behavior['up']   . g:winresizer_horiz_resize,
@@ -115,30 +137,83 @@ fun! WinResizerStartResize()
         \  'cancel' : winrestcmd(),
         \}
 
-  call s:startReize(commands)
+  return commands
+
+endfun
+
+fun! s:resizeCommands()
+  if has("gui_running") && g:winresizer_gui_enable != 0
+    return s:guiResizeCommands()
+  else
+    return s:tuiResizeCommands()
+  endif
+endfun
+
+fun! s:moveCommands()
+
+  let commands = {
+        \  'mode'   : "move",
+        \  'left'   : ":call winresizer#swapTo('left')",
+        \  'right'  : ":call winresizer#swapTo('right')",
+        \  'up'     : ":call winresizer#swapTo('up')",
+        \  'down'   : ":call winresizer#swapTo('down')",
+        \  'cancel' : winrestcmd(),
+        \}
+
+  return commands
+
+endfun
+
+fun! s:focusCommands()
+
+  let commands = {
+        \  'mode'   : "focus",
+        \  'left'   : "normal! \<c-w>h",
+        \  'right'  : "normal! \<c-w>l",
+        \  'up'     : "normal! \<c-w>k",
+        \  'down'   : "normal! \<c-w>j",
+        \  'cancel' : winrestcmd(),
+        \}
+
+  return commands
 
 endfun
 
 fun! s:startReize(commands)
 
+  if g:winresizer_enable == 0
+    return
+  endif
+
+  let s:commands = a:commands
+
   while 1
 
-    echo '[window resize mode]... "'.s:label_finish.'": OK , "'.s:label_cancel.'": Cancel'
+    echo '[window ' . s:commands['mode'] . ' mode]... "'.s:label_finish.'": OK , "'.s:label_mode.'": Mode , "'.s:label_cancel.'": Cancel '
+
     let c = getchar()
 
     if c == s:codeList['left'] "h
-      exe a:commands['left']
+      exe s:commands['left']
     elseif c == s:codeList['down'] "j
-      exe a:commands['down']
+      exe s:commands['down']
     elseif c == s:codeList['up'] "k
-      exe a:commands['up']
+      exe s:commands['up']
     elseif c == s:codeList['right'] "l
-      exe a:commands['right']
+      exe s:commands['right']
     elseif c == g:winresizer_keycode_cancel "q
-      exe a:commands['cancel']
+      exe s:commands['cancel']
       redraw
       echo "Canceled!"
       break
+    elseif c == s:codeList['mode']
+      if s:commands['mode'] == 'move'
+        let s:commands = s:focusCommands()
+      elseif s:commands['mode'] == 'focus'
+        let s:commands = s:resizeCommands()
+      else
+        let s:commands = s:moveCommands()
+      endif
     elseif c == g:winresizer_keycode_finish || (g:winresizer_finish_with_escape == 1 && c == g:winresizer_keycode_escape)
       redraw
       echo "Finished!"
@@ -187,6 +262,6 @@ endfun
 
 let s:label_finish = s:getKeyAlias(g:winresizer_keycode_finish)
 let s:label_cancel = s:getKeyAlias(g:winresizer_keycode_cancel)
-
+let s:label_mode = s:getKeyAlias(g:winresizer_keycode_mode)
 
 let &cpo = s:save_cpo

--- a/plugin/winresizer.vim
+++ b/plugin/winresizer.vim
@@ -19,6 +19,8 @@
 " k : expand window size to up
 " l : expand window size to right
 " e : switch to move mode
+" f : change to focus mode
+" w : change to move mode
 " q : cancel resize window and escape [window resize mode]
 " Enter : fix and escape 
 "
@@ -28,6 +30,8 @@
 " k : move window up
 " l : move window right
 " e : switch to focus mode
+" f : change to focus mode
+" r : change to resize mode
 " q : cancel move window and escape [window move mode]
 " Enter : fix and escape 
 "
@@ -37,8 +41,10 @@
 " k : move focus to window above
 " l : move focus to right window
 " e : switch to resize mode
+" r : change to resize mode
+" w : change to move mode
 " q : cancel move window and escape [window focus mode]
-" Enter : fix and escape 
+" Enter : fix and change to resize mode 
 
 if exists("g:loaded_winresizer")
   finish
@@ -92,7 +98,7 @@ let g:winresizer_keycode_right = get(g:, 'winresizer_keycode_right', s:default_k
 let g:winresizer_keycode_finish = get(g:, 'winresizer_keycode_finish', s:default_keycode['finish'])
 let g:winresizer_keycode_cancel = get(g:, 'winresizer_keycode_cancel', s:default_keycode['cancel'])
 let g:winresizer_keycode_escape = get(g:, 'winresizer_keycode_escape', s:default_keycode['escape'])
-let g:winresizer_keycode_escape = get(g:, 'winresizer_keycode_enter', s:default_keycode['enter'])
+let g:winresizer_keycode_enter = get(g:, 'winresizer_keycode_enter', s:default_keycode['enter'])
 let g:winresizer_keycode_mode   = get(g:, 'winresizer_keycode_mode', s:default_keycode['mode'])
 
 " if <ESC> key downed, finish resize mode
@@ -112,7 +118,7 @@ let s:codeList = {
 
 exe 'nnoremap ' . g:winresizer_start_key .' :WinResizerStartResize<CR>'
 
-com! WinResizerStartResize call s:startReize(s:resizeCommands())
+com! WinResizerStartResize call s:startReize(s:tuiResizeCommands())
 com! WinResizerStartMove call s:startReize(s:moveCommands())
 com! WinResizerStartFocus call s:startReize(s:focusCommands())
 
@@ -153,14 +159,6 @@ fun! s:tuiResizeCommands()
 
 endfun
 
-fun! s:resizeCommands()
-  if has("gui_running") && g:winresizer_gui_enable != 0
-    return s:guiResizeCommands()
-  else
-    return s:tuiResizeCommands()
-  endif
-endfun
-
 fun! s:moveCommands()
 
   let commands = {
@@ -197,42 +195,42 @@ fun! s:startReize(commands)
     return
   endif
 
-  let s:commands = a:commands
+  let l:commands = a:commands
 
   while 1
 
-    echo '[window ' . s:commands['mode'] . ' mode]... "'.s:label_finish.'": OK , "'.s:label_mode.'": Mode , "'.s:label_cancel.'": Cancel '
+    echo '[window ' . l:commands['mode'] . ' mode]... "'.s:label_finish.'": OK , "'.s:label_mode.'": Mode , "'.s:label_cancel.'": Cancel '
 
     let c = getchar()
 
     if c == s:codeList['left'] "h
-      exe s:commands['left']
+      exe l:commands['left']
     elseif c == s:codeList['down'] "j
-      exe s:commands['down']
+      exe l:commands['down']
     elseif c == s:codeList['up'] "k
-      exe s:commands['up']
+      exe l:commands['up']
     elseif c == s:codeList['right'] "l
-      exe s:commands['right']
+      exe l:commands['right']
     elseif c == s:codeList['focus'] "f
-      let s:commands = s:focusCommands()
+      let l:commands = s:focusCommands()
     elseif c == s:codeList['move'] "w
-      let s:commands = s:moveCommands()
+      let l:commands = s:moveCommands()
     elseif c == s:codeList['resize'] "r
-      let s:commands = s:resizeCommands()
-    elseif c == s:codeList['enter'] && s:commands['mode'] == "focus"
-      let s:commands = s:resizeCommands()
+      let l:commands = s:tuiResizeCommands()
+    elseif c == s:codeList['enter'] && l:commands['mode'] == "focus"
+      let l:commands = s:tuiResizeCommands()
     elseif c == g:winresizer_keycode_cancel "q
-      exe s:commands['cancel']
+      exe l:commands['cancel']
       redraw
       echo "Canceled!"
       break
     elseif c == s:codeList['mode']
-      if s:commands['mode'] == 'move'
-        let s:commands = s:focusCommands()
-      elseif s:commands['mode'] == 'focus'
-        let s:commands = s:resizeCommands()
+      if l:commands['mode'] == 'move'
+        let l:commands = s:focusCommands()
+      elseif l:commands['mode'] == 'focus'
+        let l:commands = s:tuiResizeCommands()
       else
-        let s:commands = s:moveCommands()
+        let l:commands = s:moveCommands()
       endif
     elseif c == g:winresizer_keycode_finish || (g:winresizer_finish_with_escape == 1 && c == g:winresizer_keycode_escape)
       redraw

--- a/plugin/winresizer.vim
+++ b/plugin/winresizer.vim
@@ -67,16 +67,23 @@ let g:winresizer_horiz_resize = get(g:, 'winresizer_horiz_resize', 3)
 
 " resize mode key mapping
 let s:default_keycode = {
+             \           'move'  :'119',
+             \           'focus' :'102',
+             \           'resize' :'114',
              \           'left'  :'104',
              \           'down'  :'106',
              \           'up'    :'107',
              \           'right' :'108',
              \           'finish':'13',
              \           'cancel':'113',
+             \           'enter' :'13',
              \           'escape':'27',
              \           'mode'  :'101',
              \          }
 
+let g:winresizer_keycode_focus = get(g:, 'winresizer_keycode_focus', s:default_keycode['focus'])
+let g:winresizer_keycode_move  = get(g:, 'winresizer_keycode_move', s:default_keycode['move'])
+let g:winresizer_keycode_resize = get(g:, 'winresizer_keycode_resize', s:default_keycode['resize'])
 let g:winresizer_keycode_left  = get(g:, 'winresizer_keycode_left', s:default_keycode['left'])
 let g:winresizer_keycode_down  = get(g:, 'winresizer_keycode_down',  s:default_keycode['down'])
 let g:winresizer_keycode_up    = get(g:, 'winresizer_keycode_up',    s:default_keycode['up'])
@@ -85,6 +92,7 @@ let g:winresizer_keycode_right = get(g:, 'winresizer_keycode_right', s:default_k
 let g:winresizer_keycode_finish = get(g:, 'winresizer_keycode_finish', s:default_keycode['finish'])
 let g:winresizer_keycode_cancel = get(g:, 'winresizer_keycode_cancel', s:default_keycode['cancel'])
 let g:winresizer_keycode_escape = get(g:, 'winresizer_keycode_escape', s:default_keycode['escape'])
+let g:winresizer_keycode_escape = get(g:, 'winresizer_keycode_enter', s:default_keycode['enter'])
 let g:winresizer_keycode_mode   = get(g:, 'winresizer_keycode_mode', s:default_keycode['mode'])
 
 " if <ESC> key downed, finish resize mode
@@ -95,6 +103,10 @@ let s:codeList = {
         \  'down' : g:winresizer_keycode_down,
         \  'up'   : g:winresizer_keycode_up,
         \  'right': g:winresizer_keycode_right,
+        \  'focus': g:winresizer_keycode_focus,
+        \  'move': g:winresizer_keycode_move,
+        \  'resize': g:winresizer_keycode_resize,
+        \  'enter': g:winresizer_keycode_enter,
         \  'mode' : g:winresizer_keycode_mode,
         \}
 
@@ -201,6 +213,14 @@ fun! s:startReize(commands)
       exe s:commands['up']
     elseif c == s:codeList['right'] "l
       exe s:commands['right']
+    elseif c == s:codeList['focus'] "f
+      let s:commands = s:focusCommands()
+    elseif c == s:codeList['move'] "w
+      let s:commands = s:moveCommands()
+    elseif c == s:codeList['resize'] "r
+      let s:commands = s:resizeCommands()
+    elseif c == s:codeList['enter'] && s:commands['mode'] == "focus"
+      let s:commands = s:resizeCommands()
     elseif c == g:winresizer_keycode_cancel "q
       exe s:commands['cancel']
       redraw


### PR DESCRIPTION
 - Add move mode that allows moving buffers between windows.
 - Add focus mode that allows moving the cursor between windows.
 - Add additional command (default e) to cycle between modes.

TODO:

 - Add default key shortcuts to start move and focus modes directly.