### PR TITLE
Update .gitignore to ignore help tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.un~
+doc/tags


### PR DESCRIPTION
Without this, it causes some pretty interesting issues for anyone who uses the repo. Basically, they either diverge from the upstream/original history by committing the tags, or they are forced to constantly have them as untracked content. Other vim plugins tend to ignore them so that they don't have to be included in the repo.

I've run into this issue with my submodule. It's quite frustrating, and I'd like to keep my submodule pointed at your upstream copy rather than my fork (which would be harder to maintain). Frankly, this is a pretty awesome plugin, and I'd like to keep using it. This will ease my burden.