### PR TITLE
Keep `match` highlight in window move

### DIFF
--- a/autoload/winresizer.vim
+++ b/autoload/winresizer.vim
@@ -52,13 +52,17 @@ fun! winresizer#swapTo(direct)
 endfun
 
 fun! winresizer#swapWindow(to)
-  let curNum = winnr()
-  let curBuf = bufnr( "%" )
+  let curNum   = winnr()
+  let curBuf   = bufnr( "%" )
+  let curMatch = getmatches(curNum)
   exe a:to . "wincmd w"
-  let toBuf  = bufnr( "%" )
+  let toBuf    = bufnr( "%" )
+  let toMatch  = getmatches(a:to)
   exe 'hide buf' curBuf
   exe curNum . "wincmd w"
   exe 'hide buf' toBuf
+  call setmatches(curMatch, a:to)
+  call setmatches(toMatch,  curNum)
   exe a:to ."wincmd w"
 endfun
 

--- a/autoload/winresizer.vim
+++ b/autoload/winresizer.vim
@@ -52,17 +52,23 @@ fun! winresizer#swapTo(direct)
 endfun
 
 fun! winresizer#swapWindow(to)
-  let curNum   = winnr()
-  let curBuf   = bufnr( "%" )
-  let curMatch = getmatches(curNum)
+  let curNum = winnr()
+  let curBuf = bufnr( "%" )
+  if has('patch-8.1.2018')
+    let curMatch = getmatches(curNum)
+  endif
   exe a:to . "wincmd w"
-  let toBuf    = bufnr( "%" )
-  let toMatch  = getmatches(a:to)
+  let toBuf = bufnr( "%" )
+  if has('patch-8.1.2018')
+    let toMatch = getmatches(a:to)
+  endif
   exe 'hide buf' curBuf
   exe curNum . "wincmd w"
   exe 'hide buf' toBuf
-  call setmatches(curMatch, a:to)
-  call setmatches(toMatch,  curNum)
+  if has('patch-8.1.2018')
+    call setmatches(curMatch, a:to)
+    call setmatches(toMatch,  curNum)
+  endif
   exe a:to ."wincmd w"
 endfun
 


### PR DESCRIPTION
Keep `:match` setting in window move mode.

`:match` setting being bound to the window,
winresizer's window moving should care it.

### How to Repro

```vim
:e a                                    " Open file a
:i
file a
hoge
fuga
.
:match Search /hoge/                    " file a: Highlight `hoge`

:below vnew b                           " Open file b
:i
file b
hoge
fuga
.
:match Search /fuga/                    " file b: Highlight `fuga`

<Ctrl-E>
m
h                                       " Exchange file a and b windo position

" Now `:match` highlight is correctly kept in new window position.
"
" Without this fix, `:match` highlight is not replaced correctly:
" it is bound to the window, not buffer.
```
