### PR TITLE
Error in command line window

### DIFF
--- a/autoload/winresizer.vim
+++ b/autoload/winresizer.vim
@@ -12,9 +12,16 @@ set cpo&vim
 fun! winresizer#getEdgeInfo()
   let chk_direct = ['left', 'down', 'up', 'right']
   let result = {}
-  for direct in chk_direct
-    silent! exe 'let result["' . direct . '"] = ' . !winresizer#canMoveCursorFromCurrentWindow(direct)
-  endfor
+  if getcmdwintype() ==# ''
+      for direct in chk_direct
+        silent! exe 'let result["' . direct . '"] = ' . !winresizer#canMoveCursorFromCurrentWindow(direct)
+      endfor
+  else
+      let result['left'] = 1
+      let result['down'] = 1
+      let result['up'] = 0
+      let result['right'] = 1
+  endif
   return result
 endfun
 

--- a/autoload/winresizer.vim
+++ b/autoload/winresizer.vim
@@ -13,7 +13,7 @@ fun! winresizer#getEdgeInfo()
   let chk_direct = ['left', 'down', 'up', 'right']
   let result = {}
   for direct in chk_direct
-    exe 'let result["' . direct . '"] = ' . !winresizer#canMoveCursorFromCurrentWindow(direct)
+    silent! exe 'let result["' . direct . '"] = ' . !winresizer#canMoveCursorFromCurrentWindow(direct)
   endfor
   return result
 endfun

--- a/plugin/winresizer.vim
+++ b/plugin/winresizer.vim
@@ -211,9 +211,9 @@ fun! s:startResize(commands)
       exe l:commands['up']
     elseif c == s:codeList['right'] "l
       exe l:commands['right']
-    elseif c == s:codeList['focus'] "f
+    elseif c == s:codeList['focus'] && getcmdwintype() ==# '' "f
       let l:commands = s:focusCommands()
-    elseif c == s:codeList['move'] "w
+    elseif c == s:codeList['move'] && getcmdwintype() ==# '' "w
       let l:commands = s:moveCommands()
     elseif c == s:codeList['resize'] "r
       let l:commands = s:tuiResizeCommands()
@@ -224,7 +224,7 @@ fun! s:startResize(commands)
       redraw
       echo "Canceled!"
       break
-    elseif c == s:codeList['mode']
+    elseif c == s:codeList['mode'] && getcmdwintype() ==# ''
       if l:commands['mode'] == 'move'
         let l:commands = s:focusCommands()
       elseif l:commands['mode'] == 'focus'


### PR DESCRIPTION
In command line window (`q:`), window resizer raises an error below:

```
Error detected while processing function <SNR>69_tuiResizeCommands[2]..<SNR>69_getResizeBehavior[3]..winresizer#getEdgeInfo[4]..winresizer#canMoveCursorFromCurrentWindow:
line    8:
E11: Invalid in command-line window; <CR> executes, CTRL-C quits
line   10:
E11: Invalid in command-line window; <CR> executes, CTRL-C quits
line    8:
E11: Invalid in command-line window; <CR> executes, CTRL-C quits
line   10:
E11: Invalid in command-line window; <CR> executes, CTRL-C quits
line    8:
E11: Invalid in command-line window; <CR> executes, CTRL-C quits
line   10:
E11: Invalid in command-line window; <CR> executes, CTRL-C quits
line    8:
E11: Invalid in command-line window; <CR> executes, CTRL-C quits
line   10:
E11: Invalid in command-line window; <CR> executes, CTRL-C quits
```

It checks window position (`winresizer#getEdgeInfo()`), however,
it cannot switch windows with opening command line window.

----

Suppressed the error by `silent!` anyway.

But since it fails `winresizer#getEdgeInfo()`,
resize hotkey is wrong:
for command line window opening bottom,
key `k` / `j` should window size increase / decrease, but opposite (probably default setting);
and still it raises errors in changing WindowResizer's mode (`f` / `m`).

Is there any way to know it is a command line window?
