### PR TITLE
Keep window size in window position check

### DIFF
--- a/autoload/winresizer.vim
+++ b/autoload/winresizer.vim
@@ -25,10 +25,14 @@ fun! winresizer#canMoveCursorFromCurrentWindow(direct)
   elseif index(values(map_direct), a:direct) != -1
     let direct = a:direct
   endif
+  let winwidth  = &winwidth
+  let winheight = &winheight
+  set winwidth=1 winheight=1
   let from = winnr()
   exe "wincmd " . direct
   let to = winnr()
   exe from . "wincmd w"
+  exe "set winwidth=" . winwidth " winheight=" . winheight
   return from != to
 endfun
 


### PR DESCRIPTION
Keep window size in window position check
================================================================================

On switching current window in window-focus mode,
it checks movable direction by trying `wincmd {h,j,k,l}`.

It switches current window, so, if the window size is smaller than `&winwidth` and `&winheight`,
the window is resized.

The setting `&winwidth` is `20` by default, so vertically small window is likely to be resized.

Procedure to Repro
--------------------------------------------------------------------------------

1. `:set winwidth=20`
2. `:vsplit`
3. `:wincmd |` (Change the other window size smaller than `&winwidth`)
4. Launch winresizer (`Ctrl-q`)
5. Switch to window-focus mode (`f`)
6. Switch current window (`h`, `j`, `k`, or `l`)
