### PR TITLE
Expand focus commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ The key values are ASCII values. You can find a list of mappings [here](https://
 |g:winresizer_keycode_mode|101(`e`)|Rotate a mode (Resize -> Move -> Focus -> Resize ...)|
 |g:winresizer_keycode_finish|13(`Enter`)|Fix and escape from window resize mode|
 |g:winresizer_keycode_cancel|113(`q`)|Cancel and quit window resize mode|
+|g:winresizer_keycode_split|115(`s`)|Split window horizontally (focus mode only)|
+|g:winresizer_keycode_vsplit|118(`v`)|Split window vertically (focus mode only)|
+|g:winresizer_keycode_flast|36(`$`)|Move focus to last window (focus mode only)|
+|g:winresizer_keycode_fnext|119(`w`)|Move focus to next window (focus mode only)|
+|g:winresizer_keycode_fprev|87(`W`)|Move focus to previous window (focus mode only)|
 
 If you want to resize MacVim window itself, you must set below.
 

--- a/plugin/winresizer.vim
+++ b/plugin/winresizer.vim
@@ -80,6 +80,11 @@ let s:default_keycode = {
              \           'down'  :'106',
              \           'up'    :'107',
              \           'right' :'108',
+             \           'split'  : '115',
+             \           'vsplit' : '118',
+             \           'flast'  : '36',
+             \           'fnext'  : '119',
+             \           'fprev'  : '87',
              \           'finish':'13',
              \           'cancel':'113',
              \           'enter' :'13',
@@ -87,33 +92,55 @@ let s:default_keycode = {
              \           'mode'  :'101',
              \          }
 
-let g:winresizer_keycode_focus = get(g:, 'winresizer_keycode_focus', s:default_keycode['focus'])
-let g:winresizer_keycode_move  = get(g:, 'winresizer_keycode_move', s:default_keycode['move'])
+let g:winresizer_keycode_focus  = get(g:, 'winresizer_keycode_focus',  s:default_keycode['focus'])
+let g:winresizer_keycode_move   = get(g:, 'winresizer_keycode_move',   s:default_keycode['move'])
 let g:winresizer_keycode_resize = get(g:, 'winresizer_keycode_resize', s:default_keycode['resize'])
-let g:winresizer_keycode_left  = get(g:, 'winresizer_keycode_left', s:default_keycode['left'])
-let g:winresizer_keycode_down  = get(g:, 'winresizer_keycode_down',  s:default_keycode['down'])
-let g:winresizer_keycode_up    = get(g:, 'winresizer_keycode_up',    s:default_keycode['up'])
-let g:winresizer_keycode_right = get(g:, 'winresizer_keycode_right', s:default_keycode['right'])
+let g:winresizer_keycode_left   = get(g:, 'winresizer_keycode_left',   s:default_keycode['left'])
+let g:winresizer_keycode_down   = get(g:, 'winresizer_keycode_down',   s:default_keycode['down'])
+let g:winresizer_keycode_up     = get(g:, 'winresizer_keycode_up',     s:default_keycode['up'])
+let g:winresizer_keycode_right  = get(g:, 'winresizer_keycode_right',  s:default_keycode['right'])
+
+let g:winresizer_keycode_split  = get(g:, 'winresizer_keycode_split',  s:default_keycode['split'])
+let g:winresizer_keycode_vsplit = get(g:, 'winresizer_keycode_vsplit', s:default_keycode['vsplit'])
+
+let g:winresizer_keycode_flast  = get(g:, 'winresizer_keycode_flast',  s:default_keycode['flast'])
+let g:winresizer_keycode_fnext  = get(g:, 'winresizer_keycode_fnext',  s:default_keycode['fnext'])
+let g:winresizer_keycode_fprev  = get(g:, 'winresizer_keycode_fprev',  s:default_keycode['fprev'])
 
 let g:winresizer_keycode_finish = get(g:, 'winresizer_keycode_finish', s:default_keycode['finish'])
 let g:winresizer_keycode_cancel = get(g:, 'winresizer_keycode_cancel', s:default_keycode['cancel'])
 let g:winresizer_keycode_escape = get(g:, 'winresizer_keycode_escape', s:default_keycode['escape'])
-let g:winresizer_keycode_enter = get(g:, 'winresizer_keycode_enter', s:default_keycode['enter'])
-let g:winresizer_keycode_mode   = get(g:, 'winresizer_keycode_mode', s:default_keycode['mode'])
+let g:winresizer_keycode_enter  = get(g:, 'winresizer_keycode_enter',  s:default_keycode['enter'])
+let g:winresizer_keycode_mode   = get(g:, 'winresizer_keycode_mode',   s:default_keycode['mode'])
 
 " if <ESC> key downed, finish resize mode
 let g:winresizer_finish_with_escape = get(g:, 'winresizer_finish_with_escape', 1)
 
 let s:codeList = {
-        \  'left' : g:winresizer_keycode_left,
-        \  'down' : g:winresizer_keycode_down,
-        \  'up'   : g:winresizer_keycode_up,
-        \  'right': g:winresizer_keycode_right,
-        \  'focus': g:winresizer_keycode_focus,
-        \  'move': g:winresizer_keycode_move,
-        \  'resize': g:winresizer_keycode_resize,
-        \  'enter': g:winresizer_keycode_enter,
-        \  'mode' : g:winresizer_keycode_mode,
+        \  'left'   : g:winresizer_keycode_left,
+        \  'down'   : g:winresizer_keycode_down,
+        \  'up'     : g:winresizer_keycode_up,
+        \  'right'  : g:winresizer_keycode_right,
+        \  'split'  : g:winresizer_keycode_split,
+        \  'vsplit' : g:winresizer_keycode_vsplit,
+        \  'flast'  : g:winresizer_keycode_flast,
+        \  'fnext'  : g:winresizer_keycode_fnext,
+        \  'fprev'  : g:winresizer_keycode_fprev,
+        \  'focus'  : g:winresizer_keycode_focus,
+        \  'move'   : g:winresizer_keycode_move,
+        \  'resize' : g:winresizer_keycode_resize,
+        \  'enter'  : g:winresizer_keycode_enter,
+        \  'mode'   : g:winresizer_keycode_mode,
+        \  'num0'   : '48',
+        \  'num1'   : '49',
+        \  'num2'   : '50',
+        \  'num3'   : '51',
+        \  'num4'   : '52',
+        \  'num5'   : '53',
+        \  'num6'   : '54',
+        \  'num7'   : '55',
+        \  'num8'   : '56',
+        \  'num9'   : '57',
         \}
 
 exe 'nnoremap ' . g:winresizer_start_key .' :WinResizerStartResize<CR>'
@@ -182,7 +209,21 @@ fun! s:focusCommands()
         \  'right'  : "normal! \<c-w>l",
         \  'up'     : "normal! \<c-w>k",
         \  'down'   : "normal! \<c-w>j",
+        \  'split'  : 'split',
+        \  'vsplit' : 'vsplit',
         \  'cancel' : winrestcmd(),
+        \  'num1'   : '1 wincmd w',
+        \  'num2'   : '2 wincmd w',
+        \  'num3'   : '3 wincmd w',
+        \  'num4'   : '4 wincmd w',
+        \  'num5'   : '5 wincmd w',
+        \  'num6'   : '6 wincmd w',
+        \  'num7'   : '7 wincmd w',
+        \  'num8'   : '8 wincmd w',
+        \  'num9'   : '9 wincmd w',
+        \  'flast'  : '$ wincmd w',
+        \  'fnext'  : 'wincmd w',
+        \  'fprev'  : 'wincmd W',
         \}
 
   return commands
@@ -211,6 +252,10 @@ fun! s:startResize(commands)
       exe l:commands['up']
     elseif c == s:codeList['right'] "l
       exe l:commands['right']
+    elseif c == s:codeList['split'] && exists("l:commands['split']") "s
+      exe l:commands['split']
+    elseif c == s:codeList['vsplit'] && exists("l:commands['vsplit']") "v
+      exe l:commands['vsplit']
     elseif c == s:codeList['focus'] "f
       let l:commands = s:focusCommands()
     elseif c == s:codeList['move'] "w
@@ -219,6 +264,32 @@ fun! s:startResize(commands)
       let l:commands = s:tuiResizeCommands()
     elseif c == s:codeList['enter'] && l:commands['mode'] == "focus"
       let l:commands = s:tuiResizeCommands()
+    elseif c == s:codeList['num0'] && exists("l:commands['num0']") "0
+      exe l:commands['num0']
+    elseif c == s:codeList['num1'] && exists("l:commands['num1']") "1
+      exe l:commands['num1']
+    elseif c == s:codeList['num2'] && exists("l:commands['num2']") "2
+      exe l:commands['num2']
+    elseif c == s:codeList['num3'] && exists("l:commands['num3']") "3
+      exe l:commands['num3']
+    elseif c == s:codeList['num4'] && exists("l:commands['num4']") "4
+      exe l:commands['num4']
+    elseif c == s:codeList['num5'] && exists("l:commands['num5']") "5
+      exe l:commands['num5']
+    elseif c == s:codeList['num6'] && exists("l:commands['num6']") "6
+      exe l:commands['num6']
+    elseif c == s:codeList['num7'] && exists("l:commands['num7']") "7
+      exe l:commands['num7']
+    elseif c == s:codeList['num8'] && exists("l:commands['num8']") "8
+      exe l:commands['num8']
+    elseif c == s:codeList['num9'] && exists("l:commands['num9']") "9
+      exe l:commands['num9']
+    elseif c == s:codeList['flast'] && exists("l:commands['flast']") "$
+      exe l:commands['flast']
+    elseif c == s:codeList['fnext'] && exists("l:commands['fnext']") "w
+      exe l:commands['fnext']
+    elseif c == s:codeList['fprev'] && exists("l:commands['fprev']") "W
+      exe l:commands['fprev']
     elseif c == g:winresizer_keycode_cancel "q
       exe l:commands['cancel']
       redraw

--- a/plugin/winresizer.vim
+++ b/plugin/winresizer.vim
@@ -131,7 +131,6 @@ let s:codeList = {
         \  'resize' : g:winresizer_keycode_resize,
         \  'enter'  : g:winresizer_keycode_enter,
         \  'mode'   : g:winresizer_keycode_mode,
-        \  'num0'   : '48',
         \  'num1'   : '49',
         \  'num2'   : '50',
         \  'num3'   : '51',
@@ -264,8 +263,6 @@ fun! s:startResize(commands)
       let l:commands = s:tuiResizeCommands()
     elseif c == s:codeList['enter'] && l:commands['mode'] == "focus"
       let l:commands = s:tuiResizeCommands()
-    elseif c == s:codeList['num0'] && exists("l:commands['num0']") "0
-      exe l:commands['num0']
     elseif c == s:codeList['num1'] && exists("l:commands['num1']") "1
       exe l:commands['num1']
     elseif c == s:codeList['num2'] && exists("l:commands['num2']") "2


### PR DESCRIPTION
Added commands in focus mode:

* `s`       : `split`  window
* `v`       : `vsplit` window
* `1` - `9` : Move to window 1 - 9
* `$`       : Move to the last     window
* `w`       : Move to the next     window
* `W`       : Move to the previous window
