### PR TITLE
Avoid unexpected hlsearch

### DIFF
--- a/plugin/winresizer.vim
+++ b/plugin/winresizer.vim
@@ -197,8 +197,10 @@ fun! s:startResize(commands)
 
   let l:commands = a:commands
 
-  " XXX: Disable unexpected search highlight.
-  let l:hlsearch  = &hlsearch
+  " Suppress search highlights during resize operations.
+  " Some window commands (e.g. wincmd) trigger a redraw that re-enables
+  " highlights even after :nohl, so we disable the option for the duration.
+  let l:hlsearch = &hlsearch
   set nohlsearch
 
   while 1
@@ -244,8 +246,8 @@ fun! s:startResize(commands)
     redraw
   endwhile
 
-  " XXX: Rollback the hlsearch setting.
-  exec 'set ' . (l:hlsearch ? '' : 'no') . 'hlsearch'
+  " Restore hlsearch to its original value.
+  let &hlsearch = l:hlsearch
 endfun
 
 " Decide behavior of up, down, left and right key .

--- a/plugin/winresizer.vim
+++ b/plugin/winresizer.vim
@@ -197,6 +197,10 @@ fun! s:startResize(commands)
 
   let l:commands = a:commands
 
+  " XXX: Disable unexpected search highlight.
+  let l:hlsearch  = &hlsearch
+  set nohlsearch
+
   while 1
 
     echo '[window ' . l:commands['mode'] . ' mode]... "'.s:label_finish.'": OK , "'.s:label_mode.'": Change mode , "'.s:label_cancel.'": Cancel '
@@ -239,6 +243,9 @@ fun! s:startResize(commands)
     endif
     redraw
   endwhile
+
+  " XXX: Rollback the hlsearch setting.
+  exec 'set ' . (l:hlsearch ? '' : 'no') . 'hlsearch'
 endfun
 
 " Decide behavior of up, down, left and right key .


### PR DESCRIPTION
After search and `:nohl` to turn off the highlight,
winresizer's window focus mode unexpectedly enable the search highlight.

```vim
/ /         " Search something
:nohl       " Turn off the highlight

<c-q>f      " Run winresizer focus mode
l           " Move to other window
r           " and back
            " Then, the highlight is turned on somehow.
```

To avoid this, disable '&hlsearch' option in winresizer operations.
